### PR TITLE
票数表示を棒グラフ要素内でなく、別要素にして表示上の問題に対処

### DIFF
--- a/src/components/TopAnalysisContent.tsx
+++ b/src/components/TopAnalysisContent.tsx
@@ -113,11 +113,15 @@ const TopAnalysisContent: React.FC<
                 <div
                   className={clsx(
                     'absolute top-0 -translate-y-1/2 left-0', 
-                    'bg-sky-400 rounded-md text-lg p-2 text-white',
+                    'bg-sky-400 rounded-md text-lg text-white',
                     'h-10',
                   )}
                   style={{ width: `calc(${count/maxCount*100}%)`}}
-                >
+                />
+                <div className={clsx(
+                  'absolute top-1/2 -translate-y-1/2 left-2',
+                  'text-white',
+                )}>
                   {count}票
                 </div>
                 <div className={clsx(


### PR DESCRIPTION
これで票数の割合が少なく、グラフが極端に短い場合でも
票数が改行されなくなります

#20 に対処します
同時に棒グラフが一定以下の長さにならない問題にも対処しています
