### PR TITLE
240919 top revalidate 5min

### DIFF
--- a/docker-build-production.sh
+++ b/docker-build-production.sh
@@ -13,7 +13,8 @@ export $(cat .env.production .env.local | grep -v '^#' | sed 's/#.*//' | xargs)
 docker build \
   --network host \
   -t girls-side-analysis-nextjs \
-  -f Dockerfile.nextjs.prod .
+  -f Dockerfile.nextjs.prod \
+  $@ .
 
 echo Build done!
 

--- a/src/actions/voteActions.ts
+++ b/src/actions/voteActions.ts
@@ -48,7 +48,13 @@ export const vote = async (
     data: userVotes,
   });
 
-  revalidatePath('/');
-  revalidatePath('/[charaName]');
+  // 投票ごとにトップページの内容をすぐに更新準備
+  // 負荷が高めなのでピークアクセス時にはちょっと弱小サーバだとつらいかも
+  //revalidatePath('/');
+  // 投票ごとにキャラクターごとの内容をすぐに更新準備
+  // dynamic path はもう少しパラメータを追加してやらないと
+  // （というかそもそもパス指定方法が間違っている？）
+  // 正しく適応されないらしい
+  //revalidatePath('/[charaName]');
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,8 +46,8 @@ export default function RootLayout({
         )}>
           <Header />
           <main className={clsx(
-            'flex flex-col items-center',
-            'p-5 md:px-24 md:py-5 flex-1'
+            'flex flex-col items-center self-center',
+            'p-5 md:min-w-[40rem] max-w-full lg:max-w-[55rem] flex-1'
           )}>
             {children}
           </main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -47,7 +47,9 @@ export default function RootLayout({
           <Header />
           <main className={clsx(
             'flex flex-col items-center self-center',
-            'p-5 md:min-w-[40rem] max-w-full lg:max-w-[55rem] flex-1'
+            'p-5', 
+            'md:min-w-[40rem] max-w-full lg:max-w-[55rem] flex-1',
+            'w-full'
           )}>
             {children}
           </main>


### PR DESCRIPTION
- トップページの再生成は負荷が大きいので、投票ごとでなく5分ごとに更新するように変更
- 大画面向けのレイアウト調整