### PR TITLE
security: 認可の多層防御（IDOR 修正 + API/認可ハードニング）

### DIFF
--- a/next/src/lib/apiClient.ts
+++ b/next/src/lib/apiClient.ts
@@ -1,3 +1,5 @@
+import { headers as nextHeaders } from 'next/headers'
+
 import { hc, type AppType } from '@daiius/girls-side-analysis-server-ts/client'
 
 const apiKey = process.env.API_KEY
@@ -19,4 +21,26 @@ const createCustomedFetch = (
 export const client = (
   options?: NextFetchRequestConfig
 ) => hc<AppType>(apiUrl, { fetch: createCustomedFetch(options) })
+
+// ユーザー固有データ（/votes/:id, /users/:id）用クライアント。
+// API キーに加えてリクエストの cookie を server-ts へ転送し、
+// server-ts 側でセッション（本人）検証を可能にする。
+// cookie を読むためこのクライアントを使う呼び出しは動的レンダリングになる。
+// 必ずセッション依存の文脈（Server Action / ログイン済みページ）からのみ使うこと。
+const createAuthedFetch = (
+  options?: NextFetchRequestConfig
+): typeof fetch => async (
+  input: RequestInfo | URL,
+  requestInit?: RequestInit,
+) => {
+  const headers = new Headers(requestInit?.headers)
+  headers.set('Authorization', `Bearer ${apiKey}`)
+  const cookie = (await nextHeaders()).get('cookie') ?? ''
+  if (cookie) headers.set('cookie', cookie)
+  return await fetch(input, { ...requestInit, headers, next: options })
+}
+
+export const authedClient = (
+  options?: NextFetchRequestConfig
+) => hc<AppType>(apiUrl, { fetch: createAuthedFetch(options) })
 

--- a/next/src/lib/users.ts
+++ b/next/src/lib/users.ts
@@ -1,10 +1,10 @@
-import { client } from './apiClient'
+import { client, authedClient } from './apiClient'
 
 /**
  * 最新のユーザ状況データを取得します
  */
 export const getLatestUserState = async (twitterId: string) => {
-  const res = await client().users[':id'].$get({ param: { id: twitterId }})
+  const res = await authedClient().users[':id'].$get({ param: { id: twitterId }})
   if (res.ok) {
     return await res.json()
   }
@@ -32,7 +32,7 @@ export const insertUserStatesIfUpdated = async ({
   twitterID: string;
   data: { series: number; state: string; }[];
 }) => {
-  const res = await client().users[':id'].$post({ 
+  const res = await authedClient().users[':id'].$post({
     param: { id: twitterID },
     json: data,
   })

--- a/next/src/lib/votes.ts
+++ b/next/src/lib/votes.ts
@@ -1,4 +1,9 @@
-'use server'
+// NOTE: このモジュールは 'use server' を付けないこと。
+// twitterID を引数で受け取る内部ヘルパー群であり、'use server' を付けると
+// 各 export がセッション検証なしの Server Action として公開され、
+// 任意ユーザーの投票を読み書きできる認可バイパス（IDOR）になる。
+// 公開ミューテーション面はセッションから twitterId を導出する
+// @/actions/voteActions の vote() のみに限定する。
 import { client } from './apiClient'
 import { Vote } from '@/types';
 

--- a/next/src/lib/votes.ts
+++ b/next/src/lib/votes.ts
@@ -4,7 +4,7 @@
 // 任意ユーザーの投票を読み書きできる認可バイパス（IDOR）になる。
 // 公開ミューテーション面はセッションから twitterId を導出する
 // @/actions/voteActions の vote() のみに限定する。
-import { client } from './apiClient'
+import { client, authedClient } from './apiClient'
 import { Vote } from '@/types';
 
 import { revalidatePath } from 'next/cache'
@@ -15,7 +15,7 @@ import { revalidatePath } from 'next/cache'
  * 最新のものを取得します
  */
 export const getLatestVotes = async (twitterID: string) => {
-  const res = await client().votes[':id'].$get({ param: { id: twitterID } })
+  const res = await authedClient().votes[':id'].$get({ param: { id: twitterID } })
   if (res.ok) {
     return await res.json()
   }
@@ -29,7 +29,7 @@ export const insertVotesIfUpdated = async ({
   twitterID: string;
   data: Vote[];
 }) => {
-  const res = await client().votes[':id'].$post({
+  const res = await authedClient().votes[':id'].$post({
     param: { id: twitterID },
     json: data,
   })

--- a/server-ts/src/app.ts
+++ b/server-ts/src/app.ts
@@ -25,6 +25,11 @@ import { auth } from './lib/auth'
 const apiKey = process.env.API_KEY ??
   (() => { throw new Error('process.env.API_KEY is not defined!') })()
 
+// /admin/* 用の専用キー（最小権限）。通常 API キーとは別系統で、
+// 手動リカバリ endpoint だけに権限を絞るためのもの。
+// 未設定時は後方互換のため通常 API キー保護のみで通す（警告を出す）。
+const adminApiKey = process.env.ADMIN_API_KEY
+
 const frontendOrigin = process.env.BETTER_AUTH_URL ??
   (() => { throw new Error('process.env.BETTER_AUTH_URL is not defined!') })()
 
@@ -66,6 +71,24 @@ app.use('*', async (c, next) => {
   const [bearer, apiKeyToken] = tokens
   if (bearer !== 'Bearer') return c.body(null, 400)
   if (!constantTimeEqual(apiKeyToken, apiKey)) return c.body(null, 401)
+  await next()
+})
+
+// /admin/* は通常 API キーに加えて専用の ADMIN_API_KEY を要求する（最小権限）。
+// 上の '*' ミドルウェアで API_KEY を検証済みなので、ここは追加の認可レイヤ。
+// ADMIN_API_KEY 未設定時は後方互換のため通過させるが、設定を促す警告を出す。
+app.use('/admin/*', async (c, next) => {
+  if (!adminApiKey) {
+    console.warn(
+      'ADMIN_API_KEY is not set; /admin/* is protected only by the shared API_KEY. '
+      + 'Set ADMIN_API_KEY to enable least-privilege separation.',
+    )
+    return next()
+  }
+  const adminToken = c.req.header('X-Admin-Key')
+  if (!adminToken || !constantTimeEqual(adminToken, adminApiKey)) {
+    return c.body(null, 401)
+  }
   await next()
 })
 
@@ -192,7 +215,8 @@ const route = app
   )
   // 指定日（省略時は昨日）の DailyOshiCount を生成し直す。
   // cron が失敗した時のリカバリや backfill 用。
-  // 既存の API キー認証ミドルウェア（'*'）で保護されるため追加の認証は不要。
+  // '*' の API_KEY 認証に加え、'/admin/*' ミドルウェアで ADMIN_API_KEY
+  // （設定時は X-Admin-Key ヘッダ）を要求する。
   .post(
     '/admin/aggregate-day',
     zValidator('query', z.object({

--- a/server-ts/src/app.ts
+++ b/server-ts/src/app.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from 'node:crypto'
+
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 
@@ -25,6 +27,15 @@ const apiKey = process.env.API_KEY ??
 
 const frontendOrigin = process.env.BETTER_AUTH_URL ??
   (() => { throw new Error('process.env.BETTER_AUTH_URL is not defined!') })()
+
+// API キー等のシークレット比較はタイミング攻撃を避けるため定数時間で行う。
+// timingSafeEqual は長さが異なると例外を投げるので、先に長さを比較する
+// （ランダムな高エントロピー鍵の長さ漏洩は実害なし）。
+const constantTimeEqual = (a: string, b: string): boolean => {
+  const bufA = Buffer.from(a)
+  const bufB = Buffer.from(b)
+  return bufA.length === bufB.length && timingSafeEqual(bufA, bufB)
+}
 
 export const app = new Hono()
 
@@ -54,7 +65,7 @@ app.use('*', async (c, next) => {
   if (tokens.length != 2) return c.body(null, 400)
   const [bearer, apiKeyToken] = tokens
   if (bearer !== 'Bearer') return c.body(null, 400)
-  if (apiKeyToken !== apiKey) return c.body(null, 401)
+  if (!constantTimeEqual(apiKeyToken, apiKey)) return c.body(null, 401)
   await next()
 })
 

--- a/server-ts/src/app.ts
+++ b/server-ts/src/app.ts
@@ -2,6 +2,7 @@ import { timingSafeEqual } from 'node:crypto'
 
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
+import { createMiddleware } from 'hono/factory'
 
 import { zValidator } from '@hono/zod-validator'
 import { z } from 'zod/v4'
@@ -91,6 +92,22 @@ app.use('/admin/*', async (c, next) => {
   }
   await next()
 })
+
+// /votes/:id・/users/:id はユーザー固有データなので、:id が
+// ログイン中ユーザー自身の twitterId と一致する場合のみ許可する。
+// API_KEY（サービス間認証）に加えた本人確認の多層防御で、Next 層に
+// 認可漏れがあっても他人のデータを読み書きできないようにする。
+// セッションは Next から転送された cookie を better-auth で検証して得る。
+const requireOwnId = createMiddleware(async (c, next) => {
+  const session = await auth.api.getSession({ headers: c.req.raw.headers })
+  const sessionTwitterId = session?.user.twitterId
+  if (!sessionTwitterId || sessionTwitterId !== c.req.param('id')) {
+    return c.body(null, 403)
+  }
+  await next()
+})
+app.use('/votes/:id', requireOwnId)
+app.use('/users/:id', requireOwnId)
 
 const route = app
   .get(


### PR DESCRIPTION
## 概要

セキュリティレビューで検出した認可まわりの問題を修正・ハードニングする。主眼は Next.js Server Action 経由の IDOR の解消で、加えて server-ts の API キー認証と per-user 認可を多層防御として強化する。

## 変更内容（コミット単位）

1. **fix(next): `votes.ts` の `'use server'` を削除し認可バイパスを修正**
   `twitterID` を引数で受け取る内部ヘルパーが `'use server'` によりセッション検証なしの Server Action として公開され、任意ユーザーの投票を読み書きできる IDOR になっていた。公開ミューテーション面をセッション束縛の `voteActions.vote()` のみに限定する。
2. **fix(server-ts): API キー比較を定数時間比較にする**
   `crypto.timingSafeEqual` を用いた比較に置き換え、タイミング差を排除。
3. **feat(server-ts): `/admin/*` に専用 `ADMIN_API_KEY` を要求する**
   手動リカバリ endpoint を最小権限化。通常 `API_KEY` に加え、`ADMIN_API_KEY` 設定時は `X-Admin-Key` ヘッダを要求。未設定時は後方互換のため通過させ警告を出す。
4. **feat(next): ユーザー固有 API 呼び出しで cookie を server-ts へ転送**
   `authedClient` を追加し `/votes/:id`・`/users/:id` 系の呼び出しにリクエストの cookie を転送。公開読み取り（analysis 等）は従来の `client` のままで静的レンダリングを維持。
5. **feat(server-ts): `/votes/:id`・`/users/:id` を本人のみに認可する**
   `API_KEY` 認証に加え、`:id` がログイン中ユーザーの `twitterId` と一致する場合のみ許可する `requireOwnId` を追加。セッションは Next から転送された cookie を better-auth で検証して得る。

## デプロイ時の注意

- **`ADMIN_API_KEY`（任意）**: 設定すると `/admin/aggregate-day` の手動呼び出しに `X-Admin-Key` ヘッダが必要になる。未設定なら従来どおり（警告ログのみ）。定期集計は in-process cron のため無関係。
- コミット 4（cookie 転送）→ 5（本人検証）の順で、各コミット時点でもアプリは動作する。

## 検証

- Next / server-ts ともに `tsc --noEmit` 通過。
- ローカル（dev）で手動確認: ログイン → 投票保存 → プロフィール/プレイ状況表示 → 公開ページ表示、いずれも 403 等なく正常動作。